### PR TITLE
Curly apostrophe

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-All that's missing is the fork. Heh.
+All that’s missing is the fork. Heh.

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       display: block;
       width: 400px;
       margin: 50px auto;
-      font: 30px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;
+      font: 30px monospace;
     }
     #rainbow-message {
       position: absolute;


### PR DESCRIPTION
The real [apostrophe](http://en.wikipedia.org/wiki/Apostrophe) must be _curly_ `’`, not vertical `'`. Typography matters.
