### PR TITLE
apply border-box

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,16 @@
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
 * {
-  margin:0px;
-  padding:0px;
+  margin:0;
+  padding:0;
 }
 
 #octocat {


### PR DESCRIPTION
Hereby we set the box-sizing property of all HTML elements to border-box, instead of content-box
