### PR TITLE
Add image not found text for forkit.gif

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
 <body>
 
-<img src="forkit.gif" id="octocat" alt="" />
+<img src="forkit.gif" id="octocat" alt="forkit.gif image not found" />
 
 <!-- Feel free to change this text here -->
 <p>


### PR DESCRIPTION
I set the alt attribute for the forkit.gif image in index.html to show image not found text.
