### PR TITLE
Updated casing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>Spoon-Knife</title>
-  <LINK href="styles.css" rel="stylesheet" type="text/css">
+  <link href="styles.css" rel="stylesheet" type="text/css">
 </head>
 
 <body>
@@ -14,6 +14,10 @@
 <!-- Feel free to change this text here -->
 <p>
   Fork me? Fork you, @octocat!
+</p>
+
+<p>
+  Fork? Why not spoon?
 </p>
 
 </body>


### PR DESCRIPTION
Why would <LINK> be the only upper-cased element? I lower-cased it.
