### PR TITLE
Use __STACKTRACE__ instead of stacktrace/1

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 <!-- Feel free to change this text here -->
 <p>
   Fork me? Fork you, @octocat!
+  Heh!
 </p>
 
 </body>


### PR DESCRIPTION
stacktrace/1 is deprecated and produces a compile time warning.