### PR TITLE
Fixed metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,16 +2,12 @@
 
 <html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta charset="UTF-8"/>
   <title>Spoon-Knife</title>
-  <LINK href="styles.css" rel="stylesheet" type="text/css">
+  <link href="styles.css" rel="stylesheet" type="text/css">
 </head>
-
 <body>
-
 <img src="forkit.gif" id="octocat" alt="" />
-
-<!-- Feel free to change this text here -->
 <p>
   Fork me? Fork you, @octocat!
 </p>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <html>
 <head>
   <meta charset="UTF-8"/>
+  <meta name="description" content="A demonstration project"/>
+  <meta name="author" content="octocat, MJP8"/>
   <title>Spoon-Knife</title>
   <link href="styles.css" rel="stylesheet" type="text/css">
 </head>


### PR DESCRIPTION
Instead of `http-equiv="Content-Type" content="text/html; charset=utf-8"` in index.html's `meta` tag, I put `charset="UTF-8"` because it is recommended.