### PR TITLE
Replace outdated forking guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
-For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+For some more information on how to fork a repository, [check out our docs, "Fork a repo"](https://docs.github.com/en/get-started/quickstart/fork-a-repo). Thanks! :sparkling_heart:


### PR DESCRIPTION
**Why**

The link to the original forking guide is non-existent now.

**What is changing**

The link to the outdated guide from guides.github.com is now replaced with a link to the [Fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo) doc from Github Docs.