### PR TITLE
add build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
 For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+
+## Build Instructions
+Run `make build` to build the project.


### PR DESCRIPTION
### What changed?
- Added missing build instructions in README

### Why?
- Helps new developers onboard faster

### Testing
- Verified formatting locally