### PR TITLE
Add Forge pilot conventions and repeatable docs tickets

### DIFF
--- a/.forge.yml
+++ b/.forge.yml
@@ -1,0 +1,21 @@
+version: 0.1
+
+repo:
+  default_branch: main
+
+paths:
+  docs_root: docs
+  tickets_root: docs/tickets
+  protected:
+    - .github/workflows/**
+    - .github/CODEOWNERS
+
+commands:
+  format:
+    - node -e "console.log('format not configured for pilot')"
+  lint:
+    - node -e "console.log('lint not configured for pilot')"
+  typecheck:
+    - node -e "console.log('typecheck not configured for pilot')"
+  test:
+    - node -e "console.log('test not configured for pilot')"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Type of change
+
+- [ ] Docs
+- [ ] Fix
+- [ ] Chore
+
+## Test plan
+
+<!-- What did you run or verify? -->
+
+- [ ] I validated the change locally.
+- [ ] I added notes for manual verification (if needed).
+
+## Checklist
+
+- [ ] PR title is clear and specific.
+- [ ] Scope is focused and reviewable.
+- [ ] Relevant docs are updated.
+- [ ] CI checks pass.

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,20 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: |
+            **/*.md

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Thanks for contributing to this pilot repository.
+
+## Goals
+
+This repo is used to validate Forge's end-to-end flow in a low-risk environment.
+Prefer small, reviewable changes.
+
+## Development Workflow
+
+1. Create a branch from `main`.
+2. Make focused changes with clear commit messages.
+3. Run local checks before opening a PR.
+4. Open a PR with context and a simple test plan.
+
+## Branch Naming
+
+Use one of these prefixes:
+
+- `docs/<short-description>`
+- `chore/<short-description>`
+- `fix/<short-description>`
+
+## Pull Request Expectations
+
+- Keep PRs scoped and easy to review.
+- Explain what changed and why.
+- Include a test plan, even for docs-only changes.
+- Link related tickets/issues where relevant.
+
+## Local Checks
+
+Run these before pushing:
+
+- Markdown lint (if docs changed)
+- Any project-specific checks in CI
+
+## Code of Conduct
+
+Be respectful, clear, and collaborative in reviews and discussions.

--- a/docs/tickets/forge-pilot-001.md
+++ b/docs/tickets/forge-pilot-001.md
@@ -1,0 +1,30 @@
+# Ticket: FORGE-PILOT-001 - Add pilot execution guide
+
+## Goal
+Add a concise guide that explains how to run the Forge pilot flow in this repository.
+
+## Scope
+- In scope:
+  - Add a "Forge pilot" section to `README.md` with the standard command sequence.
+- Out of scope:
+  - Any source code or workflow logic changes.
+
+## Implementation notes
+- Target files/paths:
+  - `README.md`
+- Approach:
+  - Keep instructions short and copy/paste friendly.
+
+## Acceptance criteria
+- [ ] `README.md` includes a Forge pilot section with intake, plan, implement, verify, and pr commands.
+- [ ] Instructions reference docs-only mode.
+
+## Test plan
+- Confirm command examples are valid for this repository path structure.
+- Verify markdown lint passes.
+
+## Risk tier
+- Tier 0 - Docs-only change.
+
+## Rollback
+- Revert the docs commit.

--- a/docs/tickets/forge-pilot-001.md
+++ b/docs/tickets/forge-pilot-001.md
@@ -1,30 +1,37 @@
 # Ticket: FORGE-PILOT-001 - Add pilot execution guide
 
 ## Goal
+
 Add a concise guide that explains how to run the Forge pilot flow in this repository.
 
 ## Scope
+
 - In scope:
   - Add a "Forge pilot" section to `README.md` with the standard command sequence.
 - Out of scope:
   - Any source code or workflow logic changes.
 
 ## Implementation notes
+
 - Target files/paths:
   - `README.md`
 - Approach:
   - Keep instructions short and copy/paste friendly.
 
 ## Acceptance criteria
+
 - [ ] `README.md` includes a Forge pilot section with intake, plan, implement, verify, and pr commands.
 - [ ] Instructions reference docs-only mode.
 
 ## Test plan
+
 - Confirm command examples are valid for this repository path structure.
 - Verify markdown lint passes.
 
 ## Risk tier
+
 - Tier 0 - Docs-only change.
 
 ## Rollback
+
 - Revert the docs commit.

--- a/docs/tickets/forge-pilot-002.md
+++ b/docs/tickets/forge-pilot-002.md
@@ -1,0 +1,30 @@
+# Ticket: FORGE-PILOT-002 - Add receipt quality checklist
+
+## Goal
+Document what "good" Forge receipts look like so each pilot run can be evaluated consistently.
+
+## Scope
+- In scope:
+  - Add a receipt quality checklist doc under `docs/`.
+- Out of scope:
+  - Changing Forge runtime behavior.
+
+## Implementation notes
+- Target files/paths:
+  - `docs/forge-receipt-checklist.md`
+- Approach:
+  - Define required receipt artifacts and quick pass/fail criteria.
+
+## Acceptance criteria
+- [ ] New checklist file exists with stage-by-stage checks.
+- [ ] Checklist includes receipt presence, traceability, and PR-output quality criteria.
+
+## Test plan
+- Review checklist for clarity and completeness.
+- Verify markdown lint passes.
+
+## Risk tier
+- Tier 0 - Docs-only change.
+
+## Rollback
+- Revert the docs commit.

--- a/docs/tickets/forge-pilot-002.md
+++ b/docs/tickets/forge-pilot-002.md
@@ -1,30 +1,37 @@
 # Ticket: FORGE-PILOT-002 - Add receipt quality checklist
 
 ## Goal
+
 Document what "good" Forge receipts look like so each pilot run can be evaluated consistently.
 
 ## Scope
+
 - In scope:
   - Add a receipt quality checklist doc under `docs/`.
 - Out of scope:
   - Changing Forge runtime behavior.
 
 ## Implementation notes
+
 - Target files/paths:
   - `docs/forge-receipt-checklist.md`
 - Approach:
   - Define required receipt artifacts and quick pass/fail criteria.
 
 ## Acceptance criteria
+
 - [ ] New checklist file exists with stage-by-stage checks.
 - [ ] Checklist includes receipt presence, traceability, and PR-output quality criteria.
 
 ## Test plan
+
 - Review checklist for clarity and completeness.
 - Verify markdown lint passes.
 
 ## Risk tier
+
 - Tier 0 - Docs-only change.
 
 ## Rollback
+
 - Revert the docs commit.

--- a/docs/tickets/forge-pilot-003.md
+++ b/docs/tickets/forge-pilot-003.md
@@ -1,30 +1,37 @@
 # Ticket: FORGE-PILOT-003 - Create verification failure drill
 
 ## Goal
+
 Add a controlled docs-only failure scenario to verify that Forge detect-and-report behavior is clear.
 
 ## Scope
+
 - In scope:
   - Document a repeatable failure drill using an intentionally invalid markdown example.
 - Out of scope:
   - Introducing unstable or destructive tests.
 
 ## Implementation notes
+
 - Target files/paths:
   - `docs/verify-failure-drill.md`
 - Approach:
   - Describe setup, expected verify failure signal, and cleanup/reset steps.
 
 ## Acceptance criteria
+
 - [ ] Drill doc includes setup, run commands, expected output, and cleanup.
 - [ ] Drill is safe to run repeatedly on a feature branch.
 
 ## Test plan
+
 - Walk through drill steps manually and confirm they are executable.
 - Verify markdown lint passes on committed baseline docs.
 
 ## Risk tier
+
 - Tier 1 - Intentional temporary lint failure in branch-only drill.
 
 ## Rollback
+
 - Revert drill edits or reset branch to baseline.

--- a/docs/tickets/forge-pilot-003.md
+++ b/docs/tickets/forge-pilot-003.md
@@ -1,0 +1,30 @@
+# Ticket: FORGE-PILOT-003 - Create verification failure drill
+
+## Goal
+Add a controlled docs-only failure scenario to verify that Forge detect-and-report behavior is clear.
+
+## Scope
+- In scope:
+  - Document a repeatable failure drill using an intentionally invalid markdown example.
+- Out of scope:
+  - Introducing unstable or destructive tests.
+
+## Implementation notes
+- Target files/paths:
+  - `docs/verify-failure-drill.md`
+- Approach:
+  - Describe setup, expected verify failure signal, and cleanup/reset steps.
+
+## Acceptance criteria
+- [ ] Drill doc includes setup, run commands, expected output, and cleanup.
+- [ ] Drill is safe to run repeatedly on a feature branch.
+
+## Test plan
+- Walk through drill steps manually and confirm they are executable.
+- Verify markdown lint passes on committed baseline docs.
+
+## Risk tier
+- Tier 1 - Intentional temporary lint failure in branch-only drill.
+
+## Rollback
+- Revert drill edits or reset branch to baseline.


### PR DESCRIPTION
## Summary
- Add baseline repository conventions for a realistic Forge pilot (`.forge.yml`, `CONTRIBUTING.md`, PR template, markdown lint CI)
- Seed three docs-only pilot tickets under `docs/tickets/` for repeatable intake/plan/implement/verify/pr runs
- Normalize markdown spacing in ticket files so linting is clean and deterministic

## Test plan
- [x] Confirm branch contains only intended pilot baseline files (excluding local `.vscode/`)
- [x] Validate markdown lint diagnostics for new ticket docs are clean in editor diagnostics
- [ ] Let GitHub Actions run `Markdown Lint` on this PR and confirm pass
- [ ] Merge PR and run Forge lifecycle commands against `main`


Made with [Cursor](https://cursor.com)