### PR TITLE
feat: add my-contribution.txt via MCP agent

### DIFF
--- a/my-contribution.txt
+++ b/my-contribution.txt
@@ -1,0 +1,6 @@
+This file was added by a LangChain agent using two MCP servers:
+  - @modelcontextprotocol/server-github  (forked the repo, will create PR)
+  - git_server.py (custom Python MCP)    (cloned, branched, wrote this file, committed)
+
+Contributor : sourabh-awadhiya
+Branch      : feature/mcp-agent-contribution


### PR DESCRIPTION
This PR was raised automatically by a LangChain agent that used two MCP servers — git_server.py (custom Python MCP) for all local git operations and the GitHub MCP server for forking the repo and creating this PR.