### PR TITLE
Fix duplicated closing quote in README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
-For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+For some more information on how to fork a repository, [check out our guide, "Forking Projects"](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:


### PR DESCRIPTION
## Summary
The README had a small typo — a duplicated closing quotation mark in the link text: `"Forking Projects""` instead of `"Forking Projects"`.

## Test plan
- Visually verified the markdown renders the link text correctly (no stray quote).

This is my first pull request practice, opened with the help of Claude Code. 🙂