### PR TITLE
Fix doubled closing quote in README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
-For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+For some more information on how to fork a repository, [check out our guide, "Forking Projects"](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:


### PR DESCRIPTION
Fixes a small typo in README.md: the guide link had a doubled closing quote ("Forking Projects"") instead of a single one.

This is my first PR practice via Claude Code — thanks for maintaining this repo for that purpose!
