### PR TITLE
ponytail: remove boilerplate HTML4 attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>Spoon-Knife</title>
-  <LINK href="styles.css" rel="stylesheet" type="text/css">
+  <link href="styles.css" rel="stylesheet">
 </head>
 
 <body>
 
 <img src="forkit.gif" id="octocat" alt="" />
 
-<!-- Feel free to change this text here -->
+
 <p>
   Fork me? Fork you, @octocat!
 </p>


### PR DESCRIPTION
Lazy senior dev cleanup.
- Deleted empty lines.
- Removed HTML4 type attribute on stylesheet link.