### PR TITLE
Fix stray extra quote in README link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
-For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+For some more information on how to fork a repository, [check out our guide, "Forking Projects"](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:


### PR DESCRIPTION
## Summary
- Removes a stray duplicate `"` in the README's link text for the "Forking Projects" guide, which was breaking the intended text/markdown rendering.

## Test plan
- Visual diff review of README.md (single-line text change, no build/test suite applicable).

This is my first PR, opened as practice per the repo's own instructions. Thanks!