### PR TITLE
Fix stray double-quote typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
-For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+For some more information on how to fork a repository, [check out our guide, "Forking Projects"](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:


### PR DESCRIPTION
## Summary
- Fixes a stray extra double-quote in the README link text: `"Forking Projects""]` → `"Forking Projects"]`

This is a practice PR (first PR opened with Claude Code assistance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)