### PR TITLE
Fix duplicated closing quote in README link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
-For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+For some more information on how to fork a repository, [check out our guide, "Forking Projects"](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:


### PR DESCRIPTION
The README has a small typo where the link text ends with two closing quotes instead of one: `"Forking Projects""` → `"Forking Projects"`. This fixes the rendered Markdown link text.

This is my first pull request, submitted as practice per the README's own instructions. 🙂