### PR TITLE
Improve accessibility and update outdated forking guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Creating a *fork* is producing a personal copy of someone else's project. Forks 
 
 After forking this repository, you can make some changes to the project, and submit [a Pull Request](https://github.com/octocat/Spoon-Knife/pulls) as practice.
 
-For some more information on how to fork a repository, [check out our guide, "Forking Projects""](http://guides.github.com/overviews/forking/). Thanks! :sparkling_heart:
+For some more information on how to fork a repository, [check out our guide, "Forking Projects"](https://docs.github.com/en/get-started/quickstart/fork-a-repo). Thanks! :sparkling_heart:

--- a/index.html
+++ b/index.html
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Spoon-Knife</title>
-  <LINK href="styles.css" rel="stylesheet" type="text/css">
+  <link href="styles.css" rel="stylesheet" type="text/css">
 </head>
 
 <body>
 
-<img src="forkit.gif" id="octocat" alt="" />
+<img src="forkit.gif" id="octocat" alt="Octocat holding a spoon and knife" />
 
 <!-- Feel free to change this text here -->
 <p>


### PR DESCRIPTION
## Summary

- Add `lang` attribute to `<html>` element for better screen reader support
- Replace legacy `http-equiv` charset meta tag with modern `<meta charset>`
- Add viewport meta tag for mobile responsiveness
- Lowercase `<LINK>` to `<link>` to match HTML5 standards
- Add descriptive `alt` text to Octocat image (was empty)
- Fix duplicate quote in README and update broken forking guide URL to current `docs.github.com`

## Test plan

- [ ] Verify page renders correctly in browser
- [ ] Check accessibility with a screen reader or accessibility tool
- [ ] Confirm link to forking guide resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)