### PR TITLE
Add post-fault dispatch probe (crash.js)

### DIFF
--- a/crash.js
+++ b/crash.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/**
+ * Post-fault dispatch probe: detects faults, collects diagnostics, and
+ * dispatches them to registered handlers after a crash event.
+ */
+
+const PROBE_STATES = Object.freeze({
+  IDLE: 'idle',
+  FAULTED: 'faulted',
+  DISPATCHING: 'dispatching',
+  COMPLETED: 'completed',
+});
+
+class CrashProbe {
+  constructor(options = {}) {
+    this._state = PROBE_STATES.IDLE;
+    this._faultRecord = null;
+    this._handlers = [];
+    this._maxHandlers = options.maxHandlers ?? 16;
+    this._captureStack = options.captureStack ?? true;
+    this._dispatchTimeout = options.dispatchTimeout ?? 5000;
+  }
+
+  get state() {
+    return this._state;
+  }
+
+  get faultRecord() {
+    return this._faultRecord;
+  }
+
+  /**
+   * Register a handler that receives the fault record after dispatch.
+   * Returns a deregister function.
+   */
+  onFault(handler) {
+    if (typeof handler !== 'function') {
+      throw new TypeError('handler must be a function');
+    }
+    if (this._handlers.length >= this._maxHandlers) {
+      throw new RangeError(`max handlers (${this._maxHandlers}) exceeded`);
+    }
+    this._handlers.push(handler);
+    return () => {
+      this._handlers = this._handlers.filter((h) => h !== handler);
+    };
+  }
+
+  /**
+   * Record a fault and dispatch the probe to all registered handlers.
+   * Safe to call after a crash: no exceptions are thrown; errors from
+   * handlers are collected and returned.
+   */
+  async recordFault(error, context = {}) {
+    if (!(error instanceof Error)) {
+      error = new Error(String(error));
+    }
+
+    this._state = PROBE_STATES.FAULTED;
+
+    this._faultRecord = {
+      timestamp: Date.now(),
+      message: error.message,
+      name: error.name,
+      stack: this._captureStack ? (error.stack ?? null) : null,
+      context: { ...context },
+    };
+
+    return this._dispatch();
+  }
+
+  async _dispatch() {
+    this._state = PROBE_STATES.DISPATCHING;
+
+    const record = this._faultRecord;
+    const handlerErrors = [];
+
+    const timeoutPromise = new Promise((resolve) => {
+      const t = setTimeout(resolve, this._dispatchTimeout);
+      if (typeof t.unref === 'function') t.unref();
+    });
+
+    const dispatchAll = Promise.allSettled(
+      this._handlers.map((h) =>
+        Promise.resolve()
+          .then(() => h(record))
+          .catch((err) => {
+            handlerErrors.push({ handler: h.name || '(anonymous)', error: err });
+          }),
+      ),
+    );
+
+    await Promise.race([dispatchAll, timeoutPromise]);
+
+    this._state = PROBE_STATES.COMPLETED;
+    return { record, handlerErrors };
+  }
+
+  /** Reset probe back to idle, clearing any recorded fault. */
+  reset() {
+    this._state = PROBE_STATES.IDLE;
+    this._faultRecord = null;
+  }
+}
+
+/**
+ * Attach a CrashProbe to the Node.js process, wiring up 'uncaughtException'
+ * and 'unhandledRejection' events. Returns a detach function.
+ */
+function attachToProcess(probe, proc = process) {
+  if (!(probe instanceof CrashProbe)) {
+    throw new TypeError('probe must be a CrashProbe instance');
+  }
+
+  const onUncaughtException = (err) => {
+    probe.recordFault(err, { source: 'uncaughtException' });
+  };
+
+  const onUnhandledRejection = (reason) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    probe.recordFault(err, { source: 'unhandledRejection' });
+  };
+
+  proc.on('uncaughtException', onUncaughtException);
+  proc.on('unhandledRejection', onUnhandledRejection);
+
+  return function detach() {
+    proc.off('uncaughtException', onUncaughtException);
+    proc.off('unhandledRejection', onUnhandledRejection);
+  };
+}
+
+module.exports = { CrashProbe, attachToProcess, PROBE_STATES };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "spoon-knife",
+  "version": "1.0.0",
+  "description": "Spoon-Knife with post-fault dispatch probe",
+  "main": "crash.js",
+  "scripts": {
+    "test": "node --test test/crash.test.js"
+  },
+  "license": "MIT"
+}

--- a/test/crash.test.js
+++ b/test/crash.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { CrashProbe, attachToProcess, PROBE_STATES } = require('../crash.js');
+
+describe('PROBE_STATES', () => {
+  it('exposes expected state constants', () => {
+    assert.equal(PROBE_STATES.IDLE, 'idle');
+    assert.equal(PROBE_STATES.FAULTED, 'faulted');
+    assert.equal(PROBE_STATES.DISPATCHING, 'dispatching');
+    assert.equal(PROBE_STATES.COMPLETED, 'completed');
+  });
+
+  it('is frozen', () => {
+    assert.throws(() => {
+      PROBE_STATES.NEW_STATE = 'new';
+    }, TypeError);
+  });
+});
+
+describe('CrashProbe construction', () => {
+  it('starts in idle state with no fault record', () => {
+    const probe = new CrashProbe();
+    assert.equal(probe.state, PROBE_STATES.IDLE);
+    assert.equal(probe.faultRecord, null);
+  });
+
+  it('accepts options', () => {
+    const probe = new CrashProbe({ maxHandlers: 2, captureStack: false, dispatchTimeout: 100 });
+    assert.equal(probe._maxHandlers, 2);
+    assert.equal(probe._captureStack, false);
+    assert.equal(probe._dispatchTimeout, 100);
+  });
+});
+
+describe('CrashProbe.onFault', () => {
+  it('registers a handler and returns deregister function', () => {
+    const probe = new CrashProbe();
+    const calls = [];
+    const deregister = probe.onFault((rec) => calls.push(rec));
+    assert.equal(typeof deregister, 'function');
+    assert.equal(probe._handlers.length, 1);
+    deregister();
+    assert.equal(probe._handlers.length, 0);
+  });
+
+  it('throws if handler is not a function', () => {
+    const probe = new CrashProbe();
+    assert.throws(() => probe.onFault('not-a-function'), TypeError);
+  });
+
+  it('throws when max handlers exceeded', () => {
+    const probe = new CrashProbe({ maxHandlers: 2 });
+    probe.onFault(() => {});
+    probe.onFault(() => {});
+    assert.throws(() => probe.onFault(() => {}), RangeError);
+  });
+});
+
+describe('CrashProbe.recordFault', () => {
+  let probe;
+  beforeEach(() => {
+    probe = new CrashProbe({ dispatchTimeout: 200 });
+  });
+
+  it('transitions through faulted → dispatching → completed states', async () => {
+    const states = [];
+    // Poll state after recordFault resolves
+    await probe.recordFault(new Error('boom'));
+    assert.equal(probe.state, PROBE_STATES.COMPLETED);
+  });
+
+  it('populates the fault record with error info and timestamp', async () => {
+    const before = Date.now();
+    await probe.recordFault(new Error('test error'), { requestId: '123' });
+    const after = Date.now();
+
+    const rec = probe.faultRecord;
+    assert.ok(rec, 'faultRecord should not be null');
+    assert.equal(rec.message, 'test error');
+    assert.equal(rec.name, 'Error');
+    assert.ok(rec.stack.includes('test error'));
+    assert.equal(rec.context.requestId, '123');
+    assert.ok(rec.timestamp >= before && rec.timestamp <= after);
+  });
+
+  it('wraps non-Error arguments in an Error', async () => {
+    await probe.recordFault('string fault');
+    assert.equal(probe.faultRecord.message, 'string fault');
+  });
+
+  it('omits stack when captureStack is false', async () => {
+    probe = new CrashProbe({ captureStack: false, dispatchTimeout: 200 });
+    await probe.recordFault(new Error('no stack'));
+    assert.equal(probe.faultRecord.stack, null);
+  });
+
+  it('dispatches the record to all registered handlers', async () => {
+    const received = [];
+    probe.onFault((rec) => received.push(rec));
+    probe.onFault((rec) => received.push(rec));
+
+    await probe.recordFault(new Error('dispatch test'));
+    assert.equal(received.length, 2);
+    assert.equal(received[0].message, 'dispatch test');
+  });
+
+  it('returns handler errors without throwing', async () => {
+    probe.onFault(() => {
+      throw new Error('handler exploded');
+    });
+
+    const { handlerErrors } = await probe.recordFault(new Error('fault'));
+    assert.equal(handlerErrors.length, 1);
+    assert.equal(handlerErrors[0].error.message, 'handler exploded');
+  });
+
+  it('isolates context snapshot from later mutation', async () => {
+    const ctx = { key: 'original' };
+    await probe.recordFault(new Error('ctx test'), ctx);
+    ctx.key = 'mutated';
+    assert.equal(probe.faultRecord.context.key, 'original');
+  });
+});
+
+describe('CrashProbe.reset', () => {
+  it('returns probe to idle with no fault record', async () => {
+    const probe = new CrashProbe({ dispatchTimeout: 100 });
+    await probe.recordFault(new Error('reset me'));
+    assert.equal(probe.state, PROBE_STATES.COMPLETED);
+    probe.reset();
+    assert.equal(probe.state, PROBE_STATES.IDLE);
+    assert.equal(probe.faultRecord, null);
+  });
+});
+
+describe('attachToProcess', () => {
+  it('throws if probe is not a CrashProbe', () => {
+    assert.throws(() => attachToProcess({}), TypeError);
+  });
+
+  it('registers and deregisters process listeners', () => {
+    const probe = new CrashProbe({ dispatchTimeout: 100 });
+    const fakeProcess = {
+      _listeners: {},
+      on(evt, fn) { (this._listeners[evt] = this._listeners[evt] ?? []).push(fn); },
+      off(evt, fn) { this._listeners[evt] = (this._listeners[evt] ?? []).filter((h) => h !== fn); },
+    };
+
+    const detach = attachToProcess(probe, fakeProcess);
+    assert.equal(fakeProcess._listeners['uncaughtException'].length, 1);
+    assert.equal(fakeProcess._listeners['unhandledRejection'].length, 1);
+
+    detach();
+    assert.equal(fakeProcess._listeners['uncaughtException'].length, 0);
+    assert.equal(fakeProcess._listeners['unhandledRejection'].length, 0);
+  });
+
+  it('records a fault when uncaughtException fires', async () => {
+    const probe = new CrashProbe({ dispatchTimeout: 100 });
+    const fakeProcess = {
+      _listeners: {},
+      on(evt, fn) { (this._listeners[evt] = this._listeners[evt] ?? []).push(fn); },
+      off(evt, fn) { this._listeners[evt] = (this._listeners[evt] ?? []).filter((h) => h !== fn); },
+    };
+
+    attachToProcess(probe, fakeProcess);
+    const err = new Error('uncaught!');
+    fakeProcess._listeners['uncaughtException'][0](err);
+
+    // Give async dispatch a tick to start
+    await new Promise((r) => setImmediate(r));
+    assert.ok(probe.state !== PROBE_STATES.IDLE);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `CrashProbe`, a state-machine-based crash detection and diagnostic dispatch module
- After a fault is recorded, the probe transitions `idle→faulted→dispatching→completed` and fans out the fault record to all registered handlers
- Adds `attachToProcess()` for wiring up `uncaughtException` / `unhandledRejection` on a Node.js-compatible process emitter
- Isolates handler failures so the probe itself never throws; handler errors are collected and returned

## Test plan

- [x] 18 tests covering state transitions, handler registration/deregistration, fault record structure, context snapshot isolation, error containment in handlers, and process attachment/detachment
- [x] All tests pass with `node --test test/crash.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)