### PR TITLE
Add post-fault dispatch probe with crash simulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "spoon-knife",
+  "version": "1.0.0",
+  "description": "Post-fault dispatch probe for crash recovery testing",
+  "type": "module",
+  "scripts": {
+    "test": "node --test",
+    "test:watch": "node --test --watch"
+  },
+  "devDependencies": {}
+}

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,0 +1,115 @@
+/**
+ * Task dispatcher with fault injection and crash simulation support.
+ *
+ * FaultState transitions:
+ *   HEALTHY -> FAULTED (via injectFault / crash)
+ *   FAULTED -> RECOVERING (via beginRecovery)
+ *   RECOVERING -> HEALTHY (via completeRecovery)
+ */
+
+export const FaultState = Object.freeze({
+  HEALTHY: 'HEALTHY',
+  FAULTED: 'FAULTED',
+  RECOVERING: 'RECOVERING',
+});
+
+export class DispatchError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = 'DispatchError';
+    this.cause = cause;
+  }
+}
+
+export class Dispatcher {
+  #handlers = new Map();
+  #faultState = FaultState.HEALTHY;
+  #faultReason = null;
+  #crashedAt = null;
+  #dispatchCount = 0;
+  #faultCount = 0;
+
+  get faultState() {
+    return this.#faultState;
+  }
+
+  get faultReason() {
+    return this.#faultReason;
+  }
+
+  get crashedAt() {
+    return this.#crashedAt;
+  }
+
+  get dispatchCount() {
+    return this.#dispatchCount;
+  }
+
+  get faultCount() {
+    return this.#faultCount;
+  }
+
+  register(taskType, handler) {
+    if (typeof handler !== 'function') {
+      throw new TypeError(`Handler for "${taskType}" must be a function`);
+    }
+    this.#handlers.set(taskType, handler);
+    return this;
+  }
+
+  async dispatch(task) {
+    if (this.#faultState === FaultState.FAULTED) {
+      throw new DispatchError(
+        `Dispatcher is in FAULTED state: ${this.#faultReason}`,
+        { faultReason: this.#faultReason, crashedAt: this.#crashedAt }
+      );
+    }
+
+    const handler = this.#handlers.get(task.type);
+    if (!handler) {
+      throw new DispatchError(`No handler registered for task type "${task.type}"`);
+    }
+
+    this.#dispatchCount++;
+    try {
+      return await handler(task);
+    } catch (err) {
+      this.#faultCount++;
+      this.injectFault(`Handler threw: ${err.message}`);
+      throw new DispatchError(`Dispatch failed for task type "${task.type}"`, err);
+    }
+  }
+
+  injectFault(reason = 'manual fault injection') {
+    this.#faultState = FaultState.FAULTED;
+    this.#faultReason = reason;
+    this.#crashedAt = new Date();
+  }
+
+  beginRecovery() {
+    if (this.#faultState !== FaultState.FAULTED) {
+      throw new Error(`Cannot begin recovery from state "${this.#faultState}"`);
+    }
+    this.#faultState = FaultState.RECOVERING;
+  }
+
+  completeRecovery() {
+    if (this.#faultState !== FaultState.RECOVERING) {
+      throw new Error(`Cannot complete recovery from state "${this.#faultState}"`);
+    }
+    this.#faultState = FaultState.HEALTHY;
+    this.#faultReason = null;
+    this.#crashedAt = null;
+  }
+
+  snapshot() {
+    return {
+      faultState: this.#faultState,
+      faultReason: this.#faultReason,
+      crashedAt: this.#crashedAt,
+      dispatchCount: this.#dispatchCount,
+      faultCount: this.#faultCount,
+      registeredHandlers: [...this.#handlers.keys()],
+    };
+  }
+}

--- a/src/probe.js
+++ b/src/probe.js
@@ -1,0 +1,110 @@
+/**
+ * Post-fault dispatch probe.
+ *
+ * Probes a Dispatcher after a crash or fault to assess its recovery status
+ * and determine whether it can safely resume dispatching tasks.
+ */
+
+import { FaultState } from './dispatcher.js';
+
+export const ProbeStatus = Object.freeze({
+  PASS: 'PASS',
+  DEGRADED: 'DEGRADED',
+  FAIL: 'FAIL',
+});
+
+export class ProbeResult {
+  constructor({ status, checks, snapshot, probedAt }) {
+    this.status = status;
+    this.checks = checks;
+    this.snapshot = snapshot;
+    this.probedAt = probedAt;
+  }
+
+  get passed() {
+    return this.status === ProbeStatus.PASS;
+  }
+
+  get failed() {
+    return this.status === ProbeStatus.FAIL;
+  }
+
+  get degraded() {
+    return this.status === ProbeStatus.DEGRADED;
+  }
+}
+
+/**
+ * Run a post-fault probe against a dispatcher.
+ *
+ * The probe performs a sequence of checks and returns a ProbeResult.
+ * Callers can supply additional named check functions for domain-specific
+ * validation; each check receives the dispatcher snapshot and must return
+ * { pass: boolean, detail?: string }.
+ *
+ * @param {import('./dispatcher.js').Dispatcher} dispatcher
+ * @param {{ checks?: Record<string, (snapshot: object) => { pass: boolean, detail?: string }>, probeTask?: object }} options
+ * @returns {Promise<ProbeResult>}
+ */
+export async function probePostFault(dispatcher, options = {}) {
+  const { checks: extraChecks = {}, probeTask = null } = options;
+  const snapshot = dispatcher.snapshot();
+  const probedAt = new Date();
+  const checkResults = {};
+
+  // Built-in check: dispatcher must not still be FAULTED
+  checkResults.notFaulted = {
+    pass: snapshot.faultState !== FaultState.FAULTED,
+    detail: snapshot.faultState === FaultState.FAULTED
+      ? `Dispatcher is still FAULTED: ${snapshot.faultReason}`
+      : `Fault state is ${snapshot.faultState}`,
+  };
+
+  // Built-in check: dispatcher should not be stuck in RECOVERING indefinitely
+  checkResults.notStuckRecovering = {
+    pass: snapshot.faultState !== FaultState.RECOVERING,
+    detail: snapshot.faultState === FaultState.RECOVERING
+      ? 'Dispatcher is still in RECOVERING state'
+      : `Fault state is ${snapshot.faultState}`,
+  };
+
+  // Built-in check: at least one handler registered
+  checkResults.hasHandlers = {
+    pass: snapshot.registeredHandlers.length > 0,
+    detail: snapshot.registeredHandlers.length > 0
+      ? `${snapshot.registeredHandlers.length} handler(s) registered: ${snapshot.registeredHandlers.join(', ')}`
+      : 'No handlers registered',
+  };
+
+  // Optional live dispatch probe
+  if (probeTask !== null) {
+    try {
+      await dispatcher.dispatch(probeTask);
+      checkResults.liveDispatch = { pass: true, detail: `Probe task "${probeTask.type}" dispatched successfully` };
+    } catch (err) {
+      checkResults.liveDispatch = { pass: false, detail: `Probe dispatch failed: ${err.message}` };
+    }
+  }
+
+  // User-supplied checks
+  for (const [name, fn] of Object.entries(extraChecks)) {
+    try {
+      const result = await fn(snapshot);
+      checkResults[name] = { pass: Boolean(result.pass), detail: result.detail ?? '' };
+    } catch (err) {
+      checkResults[name] = { pass: false, detail: `Check threw: ${err.message}` };
+    }
+  }
+
+  const failedChecks = Object.values(checkResults).filter(c => !c.pass);
+  let status;
+  if (failedChecks.length === 0) {
+    status = ProbeStatus.PASS;
+  } else if (checkResults.notFaulted?.pass === false || checkResults.liveDispatch?.pass === false) {
+    status = ProbeStatus.FAIL;
+  } else {
+    status = ProbeStatus.DEGRADED;
+  }
+
+  return new ProbeResult({ status, checks: checkResults, snapshot, probedAt });
+}

--- a/tests/dispatcher.test.js
+++ b/tests/dispatcher.test.js
@@ -1,0 +1,140 @@
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { Dispatcher, DispatchError, FaultState } from '../src/dispatcher.js';
+
+describe('Dispatcher', () => {
+  let dispatcher;
+
+  beforeEach(() => {
+    dispatcher = new Dispatcher();
+  });
+
+  describe('initial state', () => {
+    it('starts in HEALTHY state', () => {
+      assert.equal(dispatcher.faultState, FaultState.HEALTHY);
+    });
+
+    it('starts with zero dispatch count', () => {
+      assert.equal(dispatcher.dispatchCount, 0);
+    });
+
+    it('starts with zero fault count', () => {
+      assert.equal(dispatcher.faultCount, 0);
+    });
+  });
+
+  describe('handler registration', () => {
+    it('registers a handler and returns the dispatcher for chaining', () => {
+      const result = dispatcher.register('ping', () => 'pong');
+      assert.equal(result, dispatcher);
+    });
+
+    it('throws TypeError if handler is not a function', () => {
+      assert.throws(
+        () => dispatcher.register('bad', 'not-a-function'),
+        TypeError
+      );
+    });
+  });
+
+  describe('dispatch', () => {
+    it('calls the registered handler and returns its result', async () => {
+      dispatcher.register('echo', (task) => task.payload);
+      const result = await dispatcher.dispatch({ type: 'echo', payload: 'hello' });
+      assert.equal(result, 'hello');
+      assert.equal(dispatcher.dispatchCount, 1);
+    });
+
+    it('throws DispatchError for unregistered task types', async () => {
+      await assert.rejects(
+        () => dispatcher.dispatch({ type: 'unknown' }),
+        DispatchError
+      );
+    });
+
+    it('throws DispatchError and enters FAULTED state when handler throws', async () => {
+      dispatcher.register('bomb', () => { throw new Error('kaboom'); });
+      await assert.rejects(
+        () => dispatcher.dispatch({ type: 'bomb' }),
+        DispatchError
+      );
+      assert.equal(dispatcher.faultState, FaultState.FAULTED);
+      assert.equal(dispatcher.faultCount, 1);
+    });
+
+    it('increments dispatchCount before fault', async () => {
+      dispatcher.register('bomb', () => { throw new Error('boom'); });
+      await assert.rejects(() => dispatcher.dispatch({ type: 'bomb' }));
+      assert.equal(dispatcher.dispatchCount, 1);
+    });
+
+    it('rejects dispatch while in FAULTED state', async () => {
+      dispatcher.injectFault('test fault');
+      dispatcher.register('ok', () => 'ok');
+      await assert.rejects(
+        () => dispatcher.dispatch({ type: 'ok' }),
+        DispatchError
+      );
+    });
+  });
+
+  describe('fault injection', () => {
+    it('transitions to FAULTED state', () => {
+      dispatcher.injectFault('synthetic crash');
+      assert.equal(dispatcher.faultState, FaultState.FAULTED);
+      assert.equal(dispatcher.faultReason, 'synthetic crash');
+      assert.ok(dispatcher.crashedAt instanceof Date);
+    });
+
+    it('uses default reason when none provided', () => {
+      dispatcher.injectFault();
+      assert.ok(dispatcher.faultReason.length > 0);
+    });
+  });
+
+  describe('recovery lifecycle', () => {
+    it('transitions FAULTED -> RECOVERING -> HEALTHY', () => {
+      dispatcher.injectFault('test');
+      assert.equal(dispatcher.faultState, FaultState.FAULTED);
+
+      dispatcher.beginRecovery();
+      assert.equal(dispatcher.faultState, FaultState.RECOVERING);
+
+      dispatcher.completeRecovery();
+      assert.equal(dispatcher.faultState, FaultState.HEALTHY);
+      assert.equal(dispatcher.faultReason, null);
+      assert.equal(dispatcher.crashedAt, null);
+    });
+
+    it('throws when beginRecovery called from HEALTHY', () => {
+      assert.throws(() => dispatcher.beginRecovery(), Error);
+    });
+
+    it('throws when completeRecovery called from FAULTED', () => {
+      dispatcher.injectFault('test');
+      assert.throws(() => dispatcher.completeRecovery(), Error);
+    });
+
+    it('allows dispatch after full recovery', async () => {
+      dispatcher.register('ping', () => 'pong');
+      dispatcher.injectFault('test');
+      dispatcher.beginRecovery();
+      dispatcher.completeRecovery();
+
+      const result = await dispatcher.dispatch({ type: 'ping' });
+      assert.equal(result, 'pong');
+    });
+  });
+
+  describe('snapshot', () => {
+    it('returns current dispatcher state', () => {
+      dispatcher.register('a', () => {});
+      dispatcher.register('b', () => {});
+      const snap = dispatcher.snapshot();
+      assert.equal(snap.faultState, FaultState.HEALTHY);
+      assert.deepEqual(snap.registeredHandlers.sort(), ['a', 'b']);
+      assert.equal(snap.dispatchCount, 0);
+      assert.equal(snap.faultCount, 0);
+    });
+  });
+});

--- a/tests/probe.test.js
+++ b/tests/probe.test.js
@@ -1,0 +1,189 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { Dispatcher, FaultState } from '../src/dispatcher.js';
+import { probePostFault, ProbeStatus } from '../src/probe.js';
+
+function makeHealthyDispatcher() {
+  const d = new Dispatcher();
+  d.register('ping', () => 'pong');
+  return d;
+}
+
+function makeRecoveredDispatcher() {
+  const d = makeHealthyDispatcher();
+  d.injectFault('simulated crash');
+  d.beginRecovery();
+  d.completeRecovery();
+  return d;
+}
+
+describe('probePostFault', () => {
+  describe('on a healthy dispatcher', () => {
+    it('returns PASS when dispatcher is healthy', async () => {
+      const result = await probePostFault(makeHealthyDispatcher());
+      assert.equal(result.status, ProbeStatus.PASS);
+      assert.ok(result.passed);
+    });
+
+    it('result has a probedAt timestamp', async () => {
+      const result = await probePostFault(makeHealthyDispatcher());
+      assert.ok(result.probedAt instanceof Date);
+    });
+
+    it('result contains a snapshot', async () => {
+      const result = await probePostFault(makeHealthyDispatcher());
+      assert.equal(result.snapshot.faultState, FaultState.HEALTHY);
+    });
+  });
+
+  describe('on a faulted dispatcher', () => {
+    it('returns FAIL when dispatcher is FAULTED', async () => {
+      const d = makeHealthyDispatcher();
+      d.injectFault('test crash');
+      const result = await probePostFault(d);
+      assert.equal(result.status, ProbeStatus.FAIL);
+      assert.ok(result.failed);
+    });
+
+    it('notFaulted check fails when dispatcher is FAULTED', async () => {
+      const d = makeHealthyDispatcher();
+      d.injectFault('oops');
+      const result = await probePostFault(d);
+      assert.equal(result.checks.notFaulted.pass, false);
+    });
+  });
+
+  describe('on a dispatcher stuck in RECOVERING', () => {
+    it('returns DEGRADED when dispatcher is RECOVERING', async () => {
+      const d = makeHealthyDispatcher();
+      d.injectFault('crash');
+      d.beginRecovery();
+      const result = await probePostFault(d);
+      assert.equal(result.status, ProbeStatus.DEGRADED);
+      assert.ok(result.degraded);
+    });
+
+    it('notStuckRecovering check fails', async () => {
+      const d = makeHealthyDispatcher();
+      d.injectFault('crash');
+      d.beginRecovery();
+      const result = await probePostFault(d);
+      assert.equal(result.checks.notStuckRecovering.pass, false);
+    });
+  });
+
+  describe('on a fully recovered dispatcher', () => {
+    it('returns PASS after fault → recovery → healthy', async () => {
+      const result = await probePostFault(makeRecoveredDispatcher());
+      assert.equal(result.status, ProbeStatus.PASS);
+    });
+
+    it('all built-in checks pass', async () => {
+      const result = await probePostFault(makeRecoveredDispatcher());
+      assert.equal(result.checks.notFaulted.pass, true);
+      assert.equal(result.checks.notStuckRecovering.pass, true);
+      assert.equal(result.checks.hasHandlers.pass, true);
+    });
+  });
+
+  describe('live dispatch probe task', () => {
+    it('passes when probe task dispatches successfully', async () => {
+      const d = makeRecoveredDispatcher();
+      const result = await probePostFault(d, { probeTask: { type: 'ping' } });
+      assert.equal(result.checks.liveDispatch.pass, true);
+      assert.equal(result.status, ProbeStatus.PASS);
+    });
+
+    it('fails when probe task dispatch fails', async () => {
+      const d = makeRecoveredDispatcher();
+      const result = await probePostFault(d, { probeTask: { type: 'nonexistent' } });
+      assert.equal(result.checks.liveDispatch.pass, false);
+      assert.equal(result.status, ProbeStatus.FAIL);
+    });
+
+    it('skips liveDispatch check when no probeTask provided', async () => {
+      const result = await probePostFault(makeRecoveredDispatcher());
+      assert.equal(result.checks.liveDispatch, undefined);
+    });
+  });
+
+  describe('custom checks', () => {
+    it('includes passing custom check in PASS result', async () => {
+      const result = await probePostFault(makeRecoveredDispatcher(), {
+        checks: {
+          customOk: () => ({ pass: true, detail: 'all good' }),
+        },
+      });
+      assert.equal(result.checks.customOk.pass, true);
+      assert.equal(result.status, ProbeStatus.PASS);
+    });
+
+    it('downgrades to DEGRADED on failing custom check', async () => {
+      const result = await probePostFault(makeRecoveredDispatcher(), {
+        checks: {
+          customFail: () => ({ pass: false, detail: 'something off' }),
+        },
+      });
+      assert.equal(result.checks.customFail.pass, false);
+      assert.equal(result.status, ProbeStatus.DEGRADED);
+    });
+
+    it('handles a check that throws', async () => {
+      const result = await probePostFault(makeRecoveredDispatcher(), {
+        checks: {
+          thrower: () => { throw new Error('check explosion'); },
+        },
+      });
+      assert.equal(result.checks.thrower.pass, false);
+      assert.ok(result.checks.thrower.detail.includes('check explosion'));
+    });
+
+    it('check receives the dispatcher snapshot', async () => {
+      let receivedSnapshot = null;
+      const d = makeRecoveredDispatcher();
+      await probePostFault(d, {
+        checks: {
+          capture: (snap) => { receivedSnapshot = snap; return { pass: true }; },
+        },
+      });
+      assert.ok(receivedSnapshot !== null);
+      assert.equal(receivedSnapshot.faultState, FaultState.HEALTHY);
+    });
+  });
+
+  describe('hasHandlers check', () => {
+    it('fails when no handlers registered', async () => {
+      const d = new Dispatcher();
+      const result = await probePostFault(d);
+      assert.equal(result.checks.hasHandlers.pass, false);
+    });
+  });
+
+  describe('ProbeResult helpers', () => {
+    it('.passed is true only for PASS status', async () => {
+      const pass = await probePostFault(makeRecoveredDispatcher());
+      assert.ok(pass.passed);
+      assert.ok(!pass.failed);
+      assert.ok(!pass.degraded);
+    });
+
+    it('.failed is true only for FAIL status', async () => {
+      const d = makeHealthyDispatcher();
+      d.injectFault('crash');
+      const result = await probePostFault(d);
+      assert.ok(result.failed);
+      assert.ok(!result.passed);
+      assert.ok(!result.degraded);
+    });
+
+    it('.degraded is true only for DEGRADED status', async () => {
+      const d = makeHealthyDispatcher();
+      d.injectFault('crash');
+      d.beginRecovery();
+      const result = await probePostFault(d);
+      assert.ok(result.degraded);
+      assert.ok(!result.passed);
+      assert.ok(!result.failed);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `Dispatcher` with HEALTHY/FAULTED/RECOVERING state machine and fault injection (`injectFault`, `beginRecovery`, `completeRecovery`)
- Implements `probePostFault` that checks dispatcher health after a crash: not-faulted, not-stuck-recovering, has-handlers, optional live dispatch probe, and user-supplied custom checks
- Returns `ProbeResult` with `PASS`, `DEGRADED`, or `FAIL` status and per-check details

## Test plan

- [x] 37 tests across `tests/dispatcher.test.js` and `tests/probe.test.js`
- [x] Covers healthy/faulted/recovering states, full fault→recovery→PASS cycle, live dispatch probe success and failure, custom check pass/fail/throw, and `ProbeResult` helper properties
- [x] All tests pass: `node --test` (37 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)